### PR TITLE
Allow TVTunes to play Themes

### DIFF
--- a/skin.estuary.mod/1080i/MyVideoNav.xml
+++ b/skin.estuary.mod/1080i/MyVideoNav.xml
@@ -3,7 +3,7 @@
     <onload condition="System.HasAddon(script.tv.show.next.aired)">RunScript(script.tv.show.next.aired,backend=True)</onload>
     <!-- The following property allows TvTunes to keep playing when this window is displayed -->
     <onload condition="!IsEmpty(ListItem.TvShowTitle) + System.HasAddon(script.tvtunes)">SetProperty("TvTunesSupported", "TvShows")</onload>
-    <onload condition="IsEmpty(ListItem.TvShowTitle)+ System.HasAddon(script.tvtunes)">SetProperty("TvTunesSupported", "Movies")</onload>
+    <onload condition="IsEmpty(ListItem.TvShowTitle) + System.HasAddon(script.tvtunes)">SetProperty("TvTunesSupported", "Movies")</onload>
     <defaultcontrol always="true">50</defaultcontrol>
     <backgroundcolor>background</backgroundcolor>
     <views>50,51,52,53,54,55,500,501,502,59,58,56,57,503</views>

--- a/skin.estuary.mod/1080i/MyVideoNav.xml
+++ b/skin.estuary.mod/1080i/MyVideoNav.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
     <onload condition="System.HasAddon(script.tv.show.next.aired)">RunScript(script.tv.show.next.aired,backend=True)</onload>
+    <!-- The following property allows TvTunes to keep playing when this window is displayed -->
+    <onload condition="!IsEmpty(ListItem.TvShowTitle) + System.HasAddon(script.tvtunes)">SetProperty("TvTunesSupported", "TvShows")</onload>
+    <onload condition="IsEmpty(ListItem.TvShowTitle)+ System.HasAddon(script.tvtunes)">SetProperty("TvTunesSupported", "Movies")</onload>
     <defaultcontrol always="true">50</defaultcontrol>
     <backgroundcolor>background</backgroundcolor>
     <views>50,51,52,53,54,55,500,501,502,59,58,56,57,503</views>


### PR DESCRIPTION
As Kodi deleted some windows, Addon TVTunes is not playing themes any
more.

This Change allows TVTunes still to play themes