### PR TITLE
Correction to German Translation

### DIFF
--- a/skin.estuary.mod/language/resource.language.de_de/strings.po
+++ b/skin.estuary.mod/language/resource.language.de_de/strings.po
@@ -86,7 +86,7 @@ msgstr "Kürzlich abgespielte Kanäle"
 
 msgctxt "#31017"
 msgid "Rated"
-msgstr "Bewertung"
+msgstr "Altersfreigabe"
 
 msgctxt "#31018"
 msgid "Most played channels"


### PR DESCRIPTION
corrected
#31017

Ikarus is correct. „Altersfreigabe“ fits better