### PR TITLE
FIx: skin.estuary.mod: powermenu dialog

### DIFF
--- a/skin.estuary.mod/shortcuts/overrides.xml
+++ b/skin.estuary.mod/shortcuts/overrides.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <overrides>
+    <!-- Power menu: close before opening other window -->
+    <groupoverride group="powermenu" condition="Window.IsActive(DialogButtonMenu.xml)">Close</groupoverride>
+    
     <!-- Icons overrides -->
     <icon image="DefaultShortcut.png">special://skin/extras/icons/addtile.png</icon>
     <icon labelID="livetv">DefaultTVGuide.png</icon>


### PR DESCRIPTION
# Fix for Estuary MODs power menu
## Bug
If you add something like `ActivateWindow(...)` to the powermenu dialog, nothing happens, i.e. no window is opened.
## Fix
The power menu has to be closed before opening another window ([see my forum post](http://forum.kodi.tv/showthread.php?tid=267343&page=266)):

As stated in the [description of the skinshortcuts script](https://github.com/BigNoid/script.skinshortcuts/blob/master/resources/docs/advanced/Overriding%20an%20action.md#add-a-supplemental-action-to-all-shortcuts-in-a-menu):
> Important note: If you are using skinshortcuts to provide the powermenu (DialogButtonMenu.xml) in your skin, you MUST use this feature from Kodi Isengard (15) and higher. This is because of a change in that dialog that requires you to first close the dialog before launching any other windows.
> 
> Example (assuming the name of your powermenu is powermenu): `<groupoverride group="powermenu" condition="Window.IsActive(DialogButtonMenu.xml)">Close</groupoverride>`

So in order to fix the power menu, only the following line has to be added to skin.estuary.mod/shortcuts/overrides.xml:
```xml
<groupoverride` group="powermenu" condition="Window.IsActive(DialogButtonMenu.xml)">Close</groupoverride>
```
