### PR TITLE
Stirng replace #40165" (Hebrew)

### DIFF
--- a/skin.estuary.modv2/language/resource.language.he_il/strings.po
+++ b/skin.estuary.modv2/language/resource.language.he_il/strings.po
@@ -1530,7 +1530,7 @@ msgstr "צבע באפור פריטים שנצפו"
 #: /xml/Includes.xml
 msgctxt "#40165"
 msgid "Jump to letter"
-msgstr ""
+msgstr "דלג לאות"
 
 #: /shortcuts/overrides.xml
 msgctxt "#40166"


### PR DESCRIPTION
The string 40165 has been changed by the programmer to "jump to letter" and therefore the translation has been replaced accordingly.