### PR TITLE
rework default background handling

### DIFF
--- a/skin.estuary.modv2/language/resource.language.de_de/strings.po
+++ b/skin.estuary.modv2/language/resource.language.de_de/strings.po
@@ -2080,3 +2080,8 @@ msgstr "Ostern Theme"
 msgctxt "#40272"
 msgid "Valentine's Day Theme"
 msgstr "Valentinstag Theme"
+
+#: /xml/SkinSettings.xml
+msgctxt "#40273"
+msgid "Opacity for default background"
+msgstr "Deckkraft für Standard-Hintergrund"

--- a/skin.estuary.modv2/language/resource.language.en_gb/strings.po
+++ b/skin.estuary.modv2/language/resource.language.en_gb/strings.po
@@ -2082,3 +2082,8 @@ msgstr ""
 msgctxt "#40272"
 msgid "Valentine's Day Theme"
 msgstr ""
+
+#: /xml/SkinSettings.xml
+msgctxt "#40273"
+msgid "Opacity for default background"
+msgstr ""

--- a/skin.estuary.modv2/xml/Includes.xml
+++ b/skin.estuary.modv2/xml/Includes.xml
@@ -1730,6 +1730,15 @@
 			<aspectratio>scale</aspectratio>
 			<texture colordiffuse="$VAR[BackgroundColorVar]">special://skin/extras/backgrounds/primary.jpg</texture>
 			<visible>![[Player.HasVideo | Slideshow.IsActive] + Skin.HasSetting(opacity_100)]</visible>
+            <visible>Skin.HasSetting(enable_default_background)</visible>
+		</control>
+		<control type="image">
+			<depth>DepthBackground</depth>
+			<include>FullScreenDimensions</include>
+			<aspectratio>scale</aspectratio>
+            <texture background="true" colordiffuse="$VAR[Default_Background_Opacity]">$INFO[Skin.String(global-background)]</texture>
+            <visible>![[Player.HasVideo | Slideshow.IsActive] + Skin.HasSetting(opacity_100)]</visible>
+			<visible>!Skin.HasSetting(enable_default_background)</visible>
 		</control>
 		<control type="image">
 			<depth>DepthBackground</depth>

--- a/skin.estuary.modv2/xml/SkinSettings.xml
+++ b/skin.estuary.modv2/xml/SkinSettings.xml
@@ -6,16 +6,6 @@
 	<backgroundcolor>background</backgroundcolor>
 	<controls>
 		<include>DefaultBackground</include>
-		<control type="multiimage" id="32112">
-			<include>FullScreenDimensions</include>
-			<aspectratio>scale</aspectratio>
-			<fadetime>400</fadetime>
-			<animation effect="fade" time="400">VisibleChange</animation>
-			<imagepath background="true" colordiffuse="$VAR[Background_Opacity]">$INFO[Skin.String(global-background)]</imagepath>
-			<timeperimage>3000</timeperimage>
-			<randomize>true</randomize>
-			<visible>Skin.HasSetting(no_fanart) + !String.IsEmpty(Skin.String(global-background))</visible>
-		</control>
 		<control type="group" id="10000">
 			<left>470</left>
 			<include>OpenClose_Right</include>		
@@ -1002,14 +992,6 @@
 					<onclick>Skin.ToggleSetting(no_fanart)</onclick>
 					<selected>!Skin.HasSetting(no_fanart)</selected>
 				</control>
-				<control type="button" id="614">
-                    <label>  ∟$LOCALIZE[40265]</label>
-                    <label2>$VAR[Label_SkinSetting_GlobalBackground]</label2>
-                    <include>DefaultSettingButton</include>
-                    <onclick condition="String.IsEmpty(Skin.String(global-background))">Skin.SetImage(global-background)</onclick>
-                    <onclick condition="!String.IsEmpty(Skin.String(global-background))">Skin.Reset(global-background)</onclick>
-                    <visible>Skin.HasSetting(no_fanart)</visible>
-                </control>
 				<control type="radiobutton" id="602">
 					<label>$LOCALIZE[40059]</label>
 					<include>DefaultSettingButton</include>
@@ -1148,6 +1130,27 @@
 					<onclick>Skin.Reset(widgetAnimation9)</onclick>
 					<onclick>Skin.Reset(HomeBanner)</onclick>
 					<onclick>RunScript(script.skinshortcuts,type=resetall)</onclick>
+				</control>
+				<control type="radiobutton" id="10026">
+                    <label>$LOCALIZE[40265]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(enable_default_background)</selected>
+					<onclick>Skin.ToggleSetting(enable_default_background)</onclick>
+                </control>
+				<control type="button" id="10027">
+                    <label>  ∟$LOCALIZE[40144]</label>
+                    <label2>$VAR[Label_SkinSetting_GlobalBackground]</label2>
+                    <include>DefaultSettingButton</include>
+                    <onclick condition="String.IsEmpty(Skin.String(global-background))">Skin.SetImage(global-background)</onclick>
+                    <onclick condition="!String.IsEmpty(Skin.String(global-background))">Skin.Reset(global-background)</onclick>
+                    <visible>!Skin.HasSetting(enable_default_background)</visible>
+                </control>
+                <control type="button" id="10028">
+					<label>  ∟$LOCALIZE[40273]</label>
+					<include>DefaultSettingButton</include>
+					<onclick>Skin.SelectBool(40273, 15109|, 40038|opacity_dbg_0, 40039|opacity_dbg_5, 40040|opacity_dbg_10, 40041|opacity_dbg_15, 40042|opacity_dbg_20, 40043|opacity_dbg_25, 40044|opacity_dbg_30, 40045|opacity_dbg_35, 40046|opacity_dbg_40, 40047|opacity_dbg_45, 40048|opacity_dbg_50, 40049|opacity_dbg_55, 40050|opacity_dbg_60, 40051|opacity_dbg_65, 40052|opacity_dbg_70, 40053|opacity_dbg_75, 40054|opacity_dbg_80, 40055|opacity_dbg_85, 40056|opacity_dbg_90, 40057|opacity_dbg_95, 40058|opacity_dbg_100)</onclick>
+					<label2>$VAR[OpacitySettingDefaultBackground]</label2>
+                    <visible>!Skin.HasSetting(enable_default_background)</visible>
 				</control>
 				<control type="radiobutton" id="10006">
                     <label>$LOCALIZE[40141]</label>

--- a/skin.estuary.modv2/xml/Variables.xml
+++ b/skin.estuary.modv2/xml/Variables.xml
@@ -2798,6 +2798,30 @@
 		<value condition="Skin.HasSetting(opacity_100)">100%</value>
 		<value>$LOCALIZE[15109]</value>
 	</variable>
+	<variable name="OpacitySettingDefaultBackground">
+		<value condition="Skin.HasSetting(opacity_dbg_0)">0%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_5)">5%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_10)">10%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_15)">15%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_20)">20%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_25)">25%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_30)">30%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_35)">35%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_40)">40%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_45)">45%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_50)">50%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_55)">55%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_60)">60%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_65)">65%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_70)">70%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_75)">75%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_80)">80%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_85)">85%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_90)">90%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_95)">95%</value>
+		<value condition="Skin.HasSetting(opacity_dbg_100)">100%</value>
+		<value>$LOCALIZE[15109]</value>
+	</variable>
 	<variable name="OpacityBarsSettingLabel2Var">
 		<value condition="Skin.HasSetting(opacitybars_0)">0%</value>
 		<value condition="Skin.HasSetting(opacitybars_5)">5%</value>
@@ -2958,6 +2982,30 @@
 		<value condition="Skin.HasSetting(opacity_90)">E6FFFFFF</value>
 		<value condition="Skin.HasSetting(opacity_95)">F2FFFFFF</value>
 		<value condition="Skin.HasSetting(opacity_100)">FFFFFFFF</value>
+		<value>37FFFFFF</value>
+	</variable>
+	<variable name="Default_Background_Opacity">
+		<value condition="Skin.HasSetting(opacity_dbg_0)">00FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_5)">0DFFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_10)">1AFFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_15)">26FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_20)">33FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_25)">40FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_30)">4DFFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_35)">59FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_40)">66FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_45)">73FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_50)">80FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_55)">8CFFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_60)">99FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_65)">A6FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_70)">B3FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_75)">BFFFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_80)">CCFFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_85)">D9FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_90)">E6FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_95)">F2FFFFFF</value>
+		<value condition="Skin.HasSetting(opacity_dbg_100)">FFFFFFFF</value>
 		<value>37FFFFFF</value>
 	</variable>
 	<variable name="Bars_Opacity">


### PR DESCRIPTION
Make clean replace of skin default background with the option to adjust opacity. This prevents from showing the default blank background from skin during changing windows like in the old solution from you. Hope you accept and merge it.

PS: a tweak is needed when power menu is opened and opacity is lower than 100% (home widgets etc. are visible behind bg)