### PR TITLE
Add "reminder" button to DialogPVRInfo

### DIFF
--- a/skin.estuary.modv2/xml/DialogPVRInfo.xml
+++ b/skin.estuary.modv2/xml/DialogPVRInfo.xml
@@ -261,6 +261,14 @@
 						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 					</include>
 					<include content="InfoDialogButton">
+						<param name="id" value="450" />
+						<param name="icon" value="icons/pvr/PVR-HasTimerSchedule.png" />
+						<param name="label" value="Add reminder" />
+						<param name="onclick_1" value="Action(close)" />
+						<param name="onclick_2" value="RunScript(service.kn.switchtimer,action=add,channel=$INFO[ListItem.ChannelName],icon=$INFO[ListItem.Icon],date=$INFO[ListItem.Date],title=$INFO[ListItem.Title])" />
+						<param name="visible" value="System.hasAddon(service.kn.switchtimer)" />
+					</include>
+					<include content="InfoDialogButton">
 						<param name="id" value="10" />
 						<param name="icon" value="icons/infodialogs/play.png" />
 						<param name="label" value="$LOCALIZE[19190]" />

--- a/skin.estuary.modv2/xml/Includes_PVR.xml
+++ b/skin.estuary.modv2/xml/Includes_PVR.xml
@@ -275,4 +275,65 @@
 			<visible>!String.IsEmpty(PVR.ChannelNumberInput)</visible>
 		</control>
 	</include>
+<!-- KN SWITCHTIMER -->
+<variable name="TimerLabel">
+<value condition="!IsEmpty(Skin.String(t0:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t1:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t2:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t3:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t4:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t5:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t6:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t7:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t8:date))">$LOCALIZE[31113]</value>
+<value condition="!IsEmpty(Skin.String(t9:date))">$LOCALIZE[31113]</value>
+<value>$LOCALIZE[31114]</value>
+</variable>
+<include name="KNSwitcherContent">
+<item>
+<label>$VAR[TimerLabel]</label>
+<onclick>RunScript(service.kn.switchtimer,action=delall)</onclick>
+<property name="Icon">home/homeicons/clean.png</property>
+</item>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t0"/>
+</include>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t1"/>
+</include>
+<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t2"/>
+</include>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t3"/>
+</include>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t4"/>
+</include>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t5"/>
+</include>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t6"/>
+</include>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t7"/>
+</include>
+-<include name="KNSwitcherItem">
+<param name="knswitcheritem_id" value="t8"/>
+</include>
+</include>
+-<include name="KNSwitcherItem">
+-<item>
+<label>$INFO[Skin.String($PARAM[knswitcheritem_id]:date)]</label>
+<label2>$INFO[Skin.String($PARAM[knswitcheritem_id]:channel)]</label2>
+<onclick>RunScript(service.kn.switchtimer,action=del,timer=t$PARAM[knswitcheritem_id])</onclick>
+<property name="Title">$INFO[Skin.String($PARAM[knswitcheritem_id]:title)]</property>
+<property name="Value">$PARAM[knswitcheritem_id]</property>
+<property name="Icon">$INFO[Skin.String($PARAM[knswitcheritem_id]:icon)]</property>
+<visible>!IsEmpty(Skin.String($PARAM[knswitcheritem_id]:date))</visible>
+</item>
+</include>
+- 
+<!-- KN SWITCHTIMER CLOSE -->
 </includes>


### PR DESCRIPTION
This PR adds a button on the DialogPVRInfo screen to utilise and call  "The KN Switchtimer" addon e.g to be able to set reminders and automatically tune to a PVR channel to a program that the user had been asked to be reminded of.

Installing the KN Switchtimer does add a new line in the PVR context menu, However this isn't particularly user friendly so I believe the most natural place to add a button to call this service is along with the switch, record, add timer buttons on the DialogPVRInfo screen.

if KN Switchtimer addon is not installed then the button is hidden. Happy to discuss the merits of this addon, but i find it particularly useful and it would be great to be able to add to it to your mod.  

see screen shot:
![image](https://user-images.githubusercontent.com/11680460/35197826-72dc87d6-fedd-11e7-8448-af650b5e4dcf.png)

Still to do:
 - Find a more appropriate image for button
 - Add possible entry to skin addon support screen
- Add translation